### PR TITLE
Add LANG=C to get tr working.

### DIFF
--- a/purse.sh
+++ b/purse.sh
@@ -121,7 +121,7 @@ gen_pass () {
 write_pass () {
   # Write a password and update index file.
 
-  fpath=$(tr -dc "[:lower:]" < /dev/urandom | fold -w8 | head -n1)
+  fpath=$(LC_LANG=C tr -dc "[:lower:]" < /dev/urandom | fold -w8 | head -n1)
   spath=${safedir}/${fpath}
   printf '%s\n' "${userpass}" | \
     encrypt "${spath}" - || \


### PR DESCRIPTION
Without explicitly passing LANG=C it won't work correctly on Mac OS.

```
➜  ~ tr -dc "[:lower:]" < /dev/urandom | fold -w8 | head -n1
tr: Illegal byte sequence
➜  ~ LANG=C tr -dc "[:lower:]" < /dev/urandom | fold -w8 | head -n1
xwbersvj
```