### PR TITLE
Version 3 beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+purse.*.tar
+purse.index
+safe/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018-2020 drduh
+Copyright (c) 2018 drduh
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ Purse is a fork of [drduh/pwd.sh](https://github.com/drduh/pwd.sh).
 
 Both programs are Bash shell scripts which use [GnuPG](https://www.gnupg.org/) to manage passwords and other secrets in encrypted text files. Purse is based on asymmetric (public-key) authentication, while pwd.sh is based on symmetric (password-based) authentication.
 
-While both scripts use a trusted crypto implementation (GnuPG) and safely handle passwords (never saving plaintext to disk), Purse eliminates the need to remember and use a master password - just plug in a YubiKey, enter the PIN, then touch it to decrypt a password to clipboard.
-
-By using Purse with YubiKey, the risk of master password theft or keylogging is eliminated - only physical possession of the Yubikey AND knowledge of the PIN can unlock the encrypted index and password files.
+While both scripts use a trusted crypto implementation (GnuPG) and safely handle passwords (never saving plaintext to disk, only using shell built-ins to handle passwords), Purse eliminates the need to remember a master password - just plug in a YubiKey, enter the PIN, then touch it to decrypt a password to clipboard.
 
 # Release notes
 
@@ -27,8 +25,6 @@ Or download the script directly:
 ```console
 wget https://github.com/drduh/Purse/blob/master/purse.sh
 ```
-
-(Version 2b and older) Set the GnuPG key ID with `export PURSE_KEYID=0xFF3E7D88647EBCDB` or by editing `purse.sh`
 
 Run the script interactively using `./purse.sh` or symlink to a directory in `PATH`:
 
@@ -76,6 +72,6 @@ tar xvf purse*tar
 
 **Note** For additional privacy, the recipient key ID is **not** included in metadata (`throw-keyids` option).
 
-The password index file can also be encrypted by changing the `encrypt_index` variable to `true` in the script.
+The password index file can also be encrypted by changing the `encrypt_index` variable to `true` in the script, although two touches will be required for two separate decryption operations.
 
 See [config/gpg.conf](https://github.com/drduh/config/blob/master/gpg.conf) for additional configuration options.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Purse is a fork of [drduh/pwd.sh](https://github.com/drduh/pwd.sh).
 
 Both programs are Bash shell scripts which use [GnuPG](https://www.gnupg.org/) to manage passwords and other secrets in encrypted text files. Purse is based on asymmetric (public-key) authentication, while pwd.sh is based on symmetric (password-based) authentication.
 
-While both scripts use a trusted crypto implementation (GnuPG) and safely handle passwords (never saving plaintext to disk, only using shell built-ins to handle passwords), Purse eliminates the need to remember a master password - just plug in a YubiKey, enter the PIN, then touch it to decrypt a password to clipboard.
+While both scripts use a trusted crypto implementation (GnuPG) and safely handle passwords (never saving plaintext to disk, only using shell built-ins), Purse eliminates the need to remember a master password - just plug in a YubiKey, enter the PIN, then touch it to decrypt a password to clipboard.
 
 # Release notes
 

--- a/README.md
+++ b/README.md
@@ -2,60 +2,35 @@
 
 Purse is a fork of [drduh/pwd.sh](https://github.com/drduh/pwd.sh).
 
-Both programs are Bash shell scripts which use [GPG](https://www.gnupg.org/) to manage passwords and other secrets in encrypted text files. Purse uses asymmetric (public-key) authentication, while pwd.sh uses symmetric (password-based) authentication.
+Both programs are Bash shell scripts which use [GnuPG](https://www.gnupg.org/) to manage passwords and other secrets in encrypted text files. Purse is based on asymmetric (public-key) authentication, while pwd.sh is based on symmetric (password-based) authentication.
 
-While both scripts use a trusted crypto implementation (GPG) and safely handle passwords (never saving plaintext to disk), Purse eliminates the need to remember and use a master password - just plug in a YubiKey, enter the PIN, then touch it to decrypt a password to clipboard.
+While both scripts use a trusted crypto implementation (GnuPG) and safely handle passwords (never saving plaintext to disk), Purse eliminates the need to remember and use a master password - just plug in a YubiKey, enter the PIN, then touch it to decrypt a password to clipboard.
 
 By using Purse with YubiKey, the risk of master password theft or keylogging is eliminated - only physical possession of the Yubikey AND knowledge of the PIN can unlock the encrypted index and password files.
 
 # Release notes
 
-## Version 2b1 (2020)
-
-Minor update to the second release. Currently in beta testing. Compatible on Linux, OpenBSD, macOS.
-
-Changelist:
-
-* Purse now uses a GPG keygroup to encrypt secrets to multiple recipients for improved reliability. The program will prompt for key IDs to define the keygroup; a single key ID can still be used.
-* Encrypted index is now optional and off by default, allowing a single touch to encrypt and decrypt secrets instead of two.
-* GPG configuration file is now included in Purse backup archives.
-
-## Version 2b (2019)
-
-The second release of purse.sh features several security and reliability improvements, and is an optional upgrade. Currently in beta testing. Compatible on Linux, OpenBSD, macOS.
-
-Known issues:
-
-* Read actions now require two Yubikey touches, if touch to decrypt is enabled - once for the index and twice for the encrypted password file.
-
-Changelist:
-
-* Passwords are now encrypted as individual files, rather than all encrypted as a single flat file.
-* Individual password filenames are random, mapped to usernames in an encrypted index file.
-* Index and password files are now "immutable" using chmod while purse.sh is not running.
-* Read passwords are now copied to clipboard and cleared after a timeout, instead of printed to stdout.
-* Use printf instead of echo for improved portability.
-* New option: list passwords in the index.
-* New option: create tar archive for backup.
-* Removed option: delete password; the index is now a permanent ledger.
-* Removed option: read all passwords; no use case for having a single command.
-* Removed option: suppress generated password output; should be read from safe to verify save.
-
-## Version 1 (2018)
-
-The original release which has been available for general use and review since June 2018 (forked from pwd.sh which dates to 2015). There are no known bugs nor security vulnerabilities identified in this stable version of purse.sh.  Compatible on Linux, OpenBSD, macOS.
+See [Releases](https://github.com/drduh/Purse/releases)
 
 # Use
 
-This script requires a GPG identity - see [drduh/YubiKey-Guide](https://github.com/drduh/YubiKey-Guide) to set one up. Multiple identities stored on several YubiKeys are recommended for reliability.
+This script requires a GnuPG identity - see [drduh/YubiKey-Guide](https://github.com/drduh/YubiKey-Guide) to set one up. Multiple identities stored on several YubiKeys are recommended for improved durability and reliability.
+
+Clone the repository:
 
 ```console
-$ git clone https://github.com/drduh/Purse
+git clone https://github.com/drduh/Purse
 ```
 
-(Version 2b and older) Set your GPG key ID with `export PURSE_KEYID=0xFF3E7D88647EBCDB` or by editing `purse.sh`.
+Or download the script directly:
 
-`cd purse.sh` and run the script interactively using `./purse.sh` or symlink to a directory in `PATH`:
+```console
+wget https://github.com/drduh/Purse/blob/master/purse.sh
+```
+
+(Version 2b and older) Set the GnuPG key ID with `export PURSE_KEYID=0xFF3E7D88647EBCDB` or by editing `purse.sh`
+
+Run the script interactively using `./purse.sh` or symlink to a directory in `PATH`:
 
 * Type `w` to write a password
 * Type `r` to read a password
@@ -67,46 +42,40 @@ Options can also be passed on the command line.
 
 Example usage:
 
-Create a 30-character password for `userName`:
+Create a 20-character password for `userName`:
 
 ```console
-$ ./purse.sh w userName 30
+./purse.sh w userName 20
 ```
 
 Read password for `userName`:
 
 ```console
-$ ./purse.sh r userName
+./purse.sh r userName
 ```
 
-Passwords are stored with a timestamp for revision control. The most recent version is copied to clipboard on read. To list all passwords or read a previous version of a password:
+Passwords are stored with a timestamp for revision control. The most recent version is copied to clipboard on read. To list all passwords or read a specific version of a password:
 
 ```console
-$ ./purse.sh l
+./purse.sh l
 
-$ ./purse.sh r userName@1574723600
+./purse.sh r userName@1574723600
 ```
 
 Create an archive for backup:
 
 ```console
-$ ./purse.sh b
+./purse.sh b
 ```
 
 Restore an archive from backup:
 
 ```console
-$ tar xvf purse*tar
+tar xvf purse*tar
 ```
 
-The backup contains only encrypted passwords and can be publicly shared for use on trusted computers. For additional privacy, the recipient key ID is **not** included in GPG metadata (`throw-keyids` option). The password index file can also be encrypted by changing the `encrypt_index` variable to `true` in the script.
+**Note** For additional privacy, the recipient key ID is **not** included in metadata (`throw-keyids` option).
 
-See [drduh/config/gpg.conf](https://github.com/drduh/config/blob/master/gpg.conf) for additional GPG configuration options.
+The password index file can also be encrypted by changing the `encrypt_index` variable to `true` in the script.
 
-# Similar software
-
-* [drduh/pwd.sh](https://github.com/drduh/pwd.sh)
-* [zx2c4/password-store](https://github.com/zx2c4/password-store)
-* [caodonnell/passman.sh: a pwd.sh fork](https://github.com/caodonnell/passman.sh)
-* [bndw/pick: command-line password manager for macOS and Linux](https://github.com/bndw/pick)
-* [anders/pwgen: generate passwords using OS X Security framework](https://github.com/anders/pwgen)
+See [config/gpg.conf](https://github.com/drduh/config/blob/master/gpg.conf) for additional configuration options.


### PR DESCRIPTION
Focus on improving usability - addressing two personal issues with Purse:

* When creating passwords, having to read the password back after writing it (sometimes only to find it does not meet requirements). The password can now remain on the clipboard for the timeout duration before being saved. If the password is not compatible, just Control-C and generate a new one.
* Password generated with `gpg` often lacked special character diversity and did not meet website requirements. The character set is now a configurable `tr` setting to increase password quality.

Known Issues:

* Error handling from decryption operation does not always work
* No ability to switch between encrypted/plaintext index

Changelog:

* New option `daily_backup`: create daily backup archive on write. Off by default.
* New option `pass_copy`: keep password on clipboard before write. Helps ensure the password meets requirements before committing. Off by default.
* New option `pass_chars`: specify characters to use for password. Default is all alphanumeric and some common allowed special characters.
* Generate password with `tr` instead of `gpg` to improve compliance with password requirements.
* Reduce default password length 20->14 characters, remove maximum limit.
* Increase filename size 8->10 characters.
* Explicitly unset password variable after write.
* Minor code readability improvements.
* Add one additional error handling capability.